### PR TITLE
support clang build

### DIFF
--- a/initmake
+++ b/initmake
@@ -124,7 +124,7 @@ else
 fi
 
 cat >_autotst.c <<HERE
-main()
+int main()
 { return 0;
 }
 HERE
@@ -151,6 +151,7 @@ case "$LDFLAGS1" in
 esac
 
 cc=""
+CFLAGS ?=""
 
 for a in "$CC" cc gcc
 do
@@ -200,12 +201,12 @@ cat >_autotst.c <<HERE
 #include <sys/types.h>
 #include <stdio.h>
 #include <sys/stat.h>
-main()
+int main()
 { struct stat buf;return!&buf;
 }
 HERE
 
-CFLAGS=""
+
 
 case "$CFLAGS1" in
   *-D_POSIX_SOURCE*);;

--- a/src/autoconf
+++ b/src/autoconf
@@ -437,7 +437,7 @@ unsigned sfork()
   return pid;
 }
 
-int main(argc,argv)char*argv[];
+int main(int argc, char*argv[])
 { int goodlock,testlock,i,pip[2],pipw[2];time_t otimet;unsigned dtimet;
   static char filename[]="_locktst.l0";
   close(0);goodlock=0;testlock=FIRST_lock;signal(SIGPIPE,SIG_DFL);
@@ -587,13 +587,13 @@ int killchildren()
   return 0;
 }
 
-int sfdlock(fd)
+int sfdlock(int fd)
 { int i;unsigned gobble[GOBBLE>>2];
   for(i=GOBBLE>>2;i;gobble[--i]=~(unsigned)0);		 /* SunOS crash test */
   return fdlock(fd);
 }
 
-static oldfdlock;
+static int oldfdlock;
 #ifdef F_SETLKW
 static struct flock flck;		/* why can't it be a local variable? */
 #endif
@@ -601,7 +601,7 @@ static struct flock flck;		/* why can't it be a local variable? */
 static off_t oldlockoffset;
 #endif
 
-int fdlock(fd)
+int fdlock(int fd)
 { int i;unsigned gobble[GOBBLE>>2];
   for(i=GOBBLE>>2;i;gobble[--i]=~(unsigned)0);		 /* SunOS crash test */
   oldfdlock=fd;fd=0;


### PR DESCRIPTION
clang will trigger -Wimplicit-int, when build following code. 
```
main() {
return 0;
}
```
change to
```
int main() {
return 0;
}
```
modifications in other places are also for the same reason