### PR TITLE
Fix for capturing stdout to a variable

### DIFF
--- a/src/procmail.c
+++ b/src/procmail.c
@@ -825,9 +825,7 @@ nolock:		     { nlog("Couldn't determine implicit lockfile from");
 		  }
 	       }
 	      else if(capture)			  /* capturing stdout again? */
-	       { *(chp=strchr(capture,'='))='\0';
-		 startchar=getenv(capture);*chp='=';	  /* *NOT* tgetenv() */
-		 tobesent=startchar?strlen(startchar):0;
+	       { tobesent=startchar?strlen(startchar):0;
 		 if(!pipthrough(buf,startchar,tobesent))
 		    succeed=readvar(capture,startchar,tobesent);
 		 free(capture);


### PR DESCRIPTION
When capturing stdout to a variable, don't inexplicitly reset the message start text pointer to the contents of an environment variable (that may or may not exist) by the same name as the procmail variable we're trying to assign to.

Fix for issue https://github.com/BuGlessRB/procmail/issues/5 .