### PR TITLE
initmake: fixed build error with gcc 14: implicit return type

### DIFF
--- a/initmake
+++ b/initmake
@@ -124,7 +124,7 @@ else
 fi
 
 cat >_autotst.c <<HERE
-main()
+int main()
 { return 0;
 }
 HERE
@@ -200,7 +200,7 @@ cat >_autotst.c <<HERE
 #include <sys/types.h>
 #include <stdio.h>
 #include <sys/stat.h>
-main()
+int main()
 { struct stat buf;return!&buf;
 }
 HERE


### PR DESCRIPTION
Fixes a build error:

gcc -O _autotst.c -o _autotst
_autotst.c:1:1: error: return type defaults to ‘int’ [-Wimplicit-int]
    1 | main()
      | ^~~~
::::