### PR TITLE
Prevent race condition in parallel build

### DIFF
--- a/Makefile.1
+++ b/Makefile.1
@@ -43,7 +43,7 @@ config.check: config.h
       echo '   * Having backquotes in there could be unhealthy! *';\
  echo;fi;exit 0
 
-recommend: autoconf.h src/Makefile
+recommend: autoconf.h src/Makefile bins
 	@cd src; $(MAKE) $@
 	@echo ================================================================\
 ===============


### PR DESCRIPTION
Both make targets 'bins' and 'recommend' eventually need to link against sublib.o. The race happens when both targets are running in parallel and build sublib.o at the same time.

 - both 'bins' and 'recommend' start to compile sublib.o
 - 'recommend' - produces sublib.o
 - 'recommend' - links against sublib.o
 - 'bins' - just now finishes sublib.o overwriting the one from 'recommend'

Now user runs 'make install' and install finds that 'recommend' is older than 'sublib.o' so needs to relink 'recommend'.